### PR TITLE
[IMPROVE] Better CLI Parsing & Metadata Info

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,37 +1,144 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
-
-	flag "github.com/spf13/pflag"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
 )
 
-var encryption = flag.BoolP("encryption", "e", false, "encryption flag")
-var decryption = flag.BoolP("decryption", "d", false, "decryption flag")
+var (
+	Version     = "0.1.0-rc.1"
+	Codename    = "Hidden"
+	BuildStamp  = "0"
+	BuildDate   time.Time
+	BuildHost   = "unknown"
+	BuildUser   = "unknown"
+	IsRelease   bool
+	IsCandidate bool
+	IsBeta      bool
+	LongVersion string
+)
 
-func main() {
+const (
+	exitSuccess      = 0
+	exitErrorGeneral = 1
+	exitErrorParse   = 1
+)
 
+const (
+	usage       = "cryptogopher [options]"
+	usageDetail = `
+TODO: Add Extra Usage Details
+`
+)
+
+type RuntimeOptions struct {
+	isEncryptMode bool
+	isDecryptMode bool
+	file          string
+	quiet         bool
+	showHelp      bool
+	showVersion   bool
+}
+
+func setBuildMetadata() {
+	exp := regexp.MustCompile(`^v\d+\.\d+\.\d+(-[a-z]+[\d\.]+)?$`)
+	IsRelease = exp.MatchString(Version)
+	IsCandidate = strings.Contains(Version, "-rc.")
+	IsBeta = strings.Contains(Version, "-")
+
+	stamp, _ := strconv.Atoi(BuildStamp)
+	BuildDate = time.Unix(int64(stamp), 0)
+
+	date := BuildDate.UTC().Format("2006-01-02 15:04:05 MST")
+	LongVersion = fmt.Sprintf(`cryptogopher %s "%s" (%s %s-%s) %s@%s %s`, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, BuildUser, BuildHost, date)
+}
+
+func getDefaultRuntimeOptions() RuntimeOptions {
+	options := RuntimeOptions{
+		isEncryptMode: false,
+		isDecryptMode: false,
+		quiet:         false,
+		file:          "",
+		showHelp:      false,
+		showVersion:   false,
+	}
+
+	return options
+}
+
+func parseCommandLineOptions() RuntimeOptions {
+	options := getDefaultRuntimeOptions()
+
+	flag.BoolVar(&options.showHelp, "h", false, "Show help, then exit")
+	flag.BoolVar(&options.quiet, "q", false, "Be quiet")
+	flag.BoolVar(&options.showVersion, "v", false, "Show version")
+	flag.BoolVar(&options.isEncryptMode, "e", false, "Encrypt the given file")
+	flag.BoolVar(&options.isDecryptMode, "d", false, "Decrypt the given file")
+	flag.StringVar(&options.file, "f", options.file, "The file to be processed")
+
+	flag.Usage = usageFor(flag.CommandLine, usage, usageDetail)
 	flag.Parse()
 
-	if *encryption == false && *decryption == false {
+	if len(flag.Args()) > 0 {
+		fmt.Println("Error: Unrecognized option!")
+		//flag.Usage()
+		os.Exit(exitErrorParse)
+	}
+
+	return options
+}
+
+func main() {
+	setBuildMetadata()
+
+	options := parseCommandLineOptions()
+
+	if options.showHelp {
+		flag.Usage()
+		os.Exit(exitSuccess)
+	}
+
+	if options.showVersion {
+		fmt.Println(LongVersion)
+		os.Exit(exitSuccess)
+	}
+
+	cryptogopherMain(options)
+}
+
+func cryptogopherMain(options RuntimeOptions) {
+	if !options.isEncryptMode && !options.isDecryptMode {
 		fmt.Println("Chose the main operation: [-e] or [-d]")
+		os.Exit(exitErrorParse)
 		return
 	}
 
-	if *encryption == true && *decryption == true {
+	if options.isEncryptMode && options.isDecryptMode {
 		fmt.Println("Main operations can't set both at same time': [-e] and [-d]")
+		os.Exit(exitErrorParse)
 		return
 	}
 
-	args := os.Args[1:]
-	path := args[len(args)-1]
+	if _, err := os.Stat(options.file); os.IsNotExist(err) {
+		fmt.Println("You must enter a valid file name. Choose the file with: [-f]")
+		os.Exit(exitErrorGeneral)
+	} else {
+		if options.isEncryptMode {
+			CryptoHandler(options.file, 0)
+			os.Exit(exitSuccess)
+		}
 
-	if *encryption == true {
-		CryptoHandler(path, 0)
+		if options.isDecryptMode {
+			CryptoHandler(options.file, 1)
+			os.Exit(exitSuccess)
+		}
 	}
 
-	if *decryption == true {
-		CryptoHandler(path, 1)
-	}
+	fmt.Println("Reached end of the application..!")
 }

--- a/usage.go
+++ b/usage.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+)
+
+func optionTable(w io.Writer, rows [][]string) {
+	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+	for _, row := range rows {
+		for i, cell := range row {
+			if i > 0 {
+				tw.Write([]byte("\t"))
+			}
+			tw.Write([]byte(cell))
+		}
+		tw.Write([]byte("\n"))
+	}
+	tw.Flush()
+}
+
+func usageFor(fs *flag.FlagSet, usage string, extra string) func() {
+	return func() {
+		var b bytes.Buffer
+		b.WriteString("Usage:\n  " + usage + "\n")
+
+		var options [][]string
+		fs.VisitAll(func(f *flag.Flag) {
+			var opt = "  -" + f.Name
+
+			if f.DefValue != "false" {
+				opt += "=" + fmt.Sprintf(`"%s"`, f.DefValue)
+			}
+			options = append(options, []string{opt, f.Usage})
+		})
+
+		if len(options) > 0 {
+			b.WriteString("\nOptions:\n")
+			optionTable(&b, options)
+		}
+
+		fmt.Println(b.String())
+
+		if len(extra) > 0 {
+			fmt.Println(extra)
+		}
+	}
+}


### PR DESCRIPTION
Better CLI Parser and Metadata Info, PR. (from my **[feature/cli](https://github.com/Dentrax/cryptogopher/tree/feature/cli)** branch)

**[`pflag`](github.com/spf13/pflag) is now obsolete!**

I just removed the `github.com/spf13/pflag` to use Go's official [`flag`](https://golang.org/pkg/flag/) package.

**New CLI Options**

```
  -d     Decrypt the given file
  -e     Encrypt the given file
  -f=""  The file to be processed
  -h     Show help, then exit
  -q     Be quiet
  -v     Show version
```
**New Version Metadata**

`cryptogopher 0.1.0-rc.1 "Hidden" (go1.11.2 linux-amd64) unknown@unknown 2018-12-06 00:21:40 UTC`

**New Usage**

To _Encrypt_ a file: `./cryptogopher -e -f test.org`

To _Decrypt_ a file: `./cryptogopher -d -f test.org`

**Why `-f` Argument?**

Because, we may use  `-d` option to encrypt the folder directories, in the future, maybe.

Example: `./cryptogopher -e -d folder/`

_P.S: I've done all the unit tests._